### PR TITLE
Update setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,9 +66,11 @@ If you use this package, please cite the `ptype paper`_, using the following Bib
 Install requirements
 ====================
 
+You can simply install ptype from PyPI:
+
 .. code:: bash
 
-    pip install -r requirements.txt
+    pip install ptype
 
 =====
 Usage

--- a/ptype/__init__.py
+++ b/ptype/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from .__version__ import version

--- a/ptype/__init__.py
+++ b/ptype/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-from .__version__ import version
+from .__version__ import __version__

--- a/ptype/__version__.py
+++ b/ptype/__version__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+VERSION = (0, 2, 9)
+
+__version__ = ".".join(map(str, VERSION))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-# Used for Binder, see setup.py for package dependencies
+# Used for Binder and build/publish, see setup.py for package dependencies
 -e .[dev]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,2 @@
-# Dependencies used for Binder, see setup.py for package dependencies
-joblib>=0.17.0
-jsonpickle>=1.4.0
-clevercsv>=0.6.0
-greenery>=3.2
-matplotlib>=3.3.0
-nbval>=0.9.6
-numpy>=1.19.0
-pandas>=1.1.0
-scipy>=1.5.0
-scikit-learn>=0.22.0
-wheel
+# Used for Binder, see setup.py for package dependencies
+-e .[dev]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# Dependencies used for Binder, see setup.py for package dependencies
 joblib>=0.17.0
 jsonpickle>=1.4.0
 clevercsv>=0.6.0

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,101 @@
-import setuptools
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
-with open("README.rst", "r") as fh:
-   long_description = fh.read()
+import io
+import os
 
-setuptools.setup(
-   name='ptype',
-   version='0.2.9',
-   description='Probabilistic type inference',
-   long_description=long_description,
-   long_description_content_type="text/x-rst",
-   author='Taha Ceritli, Christopher K. I. Williams, James Geddes, Roly Perera',
-   author_email='t.y.ceritli@sms.ed.ac.uk, ckiw@inf.ed.ac.uk, jgeddes@turing.ac.uk, rperera@turing.ac.uk',
-   url='https://github.com/alan-turing-institute/ptype',
-   packages=setuptools.find_packages(),
-   classifiers=[
-        "Programming Language :: Python :: 3",
+from setuptools import find_packages, setup
+
+# Package meta-data.
+AUTHOR = "Taha Ceritli, Christopher K. I. Williams, James Geddes, Roly Perera"
+DESCRIPTION = "Probabilistic type inference"
+EMAIL = "t.y.ceritli@sms.ed.ac.uk, ckiw@inf.ed.ac.uk, jgeddes@turing.ac.uk, rperera@turing.ac.uk"
+LICENSE = "MIT"
+LICENSE_TROVE = "License :: OSI Approved :: MIT License"
+NAME = "ptype"
+REQUIRES_PYTHON = ">=3.6.0"
+URL = "https://github.com/alan-turing-institute/ptype"
+VERSION = None
+
+# What packages are required for this module to be executed?
+REQUIRED = [
+    "joblib>=0.17.0",
+    "jsonpickle>=1.4.0",
+    "clevercsv>=0.6.0",
+    "greenery>=3.2",
+    "matplotlib>=3.3.0",
+    "nbval>=0.9.6",
+    "numpy>=1.19.0",
+    "pandas>=1.1.0",
+    "scipy>=1.5.0",
+    "scikit-learn>=0.22.0",
+    "wheel",
+]
+
+full_require = []
+docs_require = []
+test_require = []
+dev_require = []
+
+# What packages are optional?
+EXTRAS = {
+    "full": full_require,
+    "docs": docs_require,
+    "test": test_require + full_require,
+    "dev": docs_require + test_require + dev_require + full_require,
+}
+
+# The rest you shouldn't have to touch too much :)
+# ------------------------------------------------
+# Except, perhaps the License and Trove Classifiers!
+# If you do change the License, remember to change the Trove Classifier for that!
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+# Import the README and use it as the long-description.
+# Note: this will only work if 'README.md' is present in your MANIFEST.in file!
+try:
+    with io.open(os.path.join(here, "README.rst"), encoding="utf-8") as f:
+        long_description = "\n" + f.read()
+except FileNotFoundError:
+    long_description = DESCRIPTION
+
+# Load the package's __version__.py module as a dictionary.
+about = {}
+if not VERSION:
+    project_slug = NAME.lower().replace("-", "_").replace(" ", "_")
+    with open(os.path.join(here, project_slug, "__version__.py")) as f:
+        exec(f.read(), about)
+else:
+    about["__version__"] = VERSION
+
+# Where the magic happens:
+setup(
+    name=NAME,
+    version=about["__version__"],
+    description=DESCRIPTION,
+    long_description=long_description,
+    long_description_content_type="text/x-rst",
+    author=AUTHOR,
+    author_email=EMAIL,
+    python_requires=REQUIRES_PYTHON,
+    url=URL,
+    packages=find_packages(
+        exclude=["tests", "*.tests", "*.tests.*", "tests.*"]
+    ),
+    install_requires=REQUIRED,
+    extras_require=EXTRAS,
+    include_package_data=True,
+    license=LICENSE,
+    ext_modules=[],
+    classifiers=[
+        # Trove classifiers
+        # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
+        LICENSE_TROVE,
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-   ],
-   install_requires=['numpy', 'scipy', 'scikit-learn', 'matplotlib', 'pandas', 'greenery', 'clevercsv']
+        "Programming Language :: Python :: 3",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Utilities",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -19,30 +19,23 @@ VERSION = None
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    "joblib>=0.17.0",
-    "jsonpickle>=1.4.0",
-    "clevercsv>=0.6.0",
     "greenery>=3.2",
+    "joblib>=0.17.0",
     "matplotlib>=3.3.0",
-    "nbval>=0.9.6",
     "numpy>=1.19.0",
     "pandas>=1.1.0",
     "scipy>=1.5.0",
-    "scikit-learn>=0.22.0",
-    "wheel",
 ]
 
-full_require = []
-docs_require = []
-test_require = []
-dev_require = []
+docs_require = ["clevercsv>=0.6.0", "scikit-learn>=0.22.0"]
+test_require = ["jsonpickle>=1.4.0", "nbval>=0.9.6"]
+dev_require = ["wheel"]
 
 # What packages are optional?
 EXTRAS = {
-    "full": full_require,
     "docs": docs_require,
-    "test": test_require + full_require,
-    "dev": docs_require + test_require + dev_require + full_require,
+    "test": test_require,
+    "dev": docs_require + test_require + dev_require,
 }
 
 # The rest you shouldn't have to touch too much :)


### PR DESCRIPTION
This follows the "setup.py for humans" example here: https://github.com/navdeep-G/setup.py, as well as the docs/test/dev extra requirements suggested [here](https://snarky.ca/clarifying-pep-518/).

Note that I've also pulled out the version to a special ``__version__.py`` file, so it can be extracted from the installed package (using ``import ptype ; ptype.__version__``). I'm not sure if this will affect your build-publish workflow, so please double check before merging.

The requirements.txt file is simplified to ensure both Binder and the build/publish scripts always get the full dependencies.